### PR TITLE
Add makepkg.conf to improve build times

### DIFF
--- a/catos-iso-for-nvidia/airootfs/etc/makepkg.conf
+++ b/catos-iso-for-nvidia/airootfs/etc/makepkg.conf
@@ -1,0 +1,165 @@
+#!/hint/bash
+# shellcheck disable=2034
+
+#
+# /etc/makepkg.conf
+#
+
+#########################################################################
+# SOURCE ACQUISITION
+#########################################################################
+#
+#-- The download utilities that makepkg should use to acquire sources
+#  Format: 'protocol::agent'
+DLAGENTS=('file::/usr/bin/curl -qgC - -o %o %u'
+          'ftp::/usr/bin/curl -qgfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o %u'
+          'http::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'https::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'rsync::/usr/bin/rsync --no-motd -z %u %o'
+          'scp::/usr/bin/scp -C %u %o')
+
+# Other common tools:
+# /usr/bin/snarf
+# /usr/bin/lftpget -c
+# /usr/bin/wget
+
+#-- The package required by makepkg to download VCS sources
+#  Format: 'protocol::package'
+VCSCLIENTS=('bzr::breezy'
+            'fossil::fossil'
+            'git::git'
+            'hg::mercurial'
+            'svn::subversion')
+
+#########################################################################
+# ARCHITECTURE, COMPILE FLAGS
+#########################################################################
+#
+CARCH="x86_64"
+CHOST="x86_64-pc-linux-gnu"
+
+#-- Compiler and Linker Flags
+#CPPFLAGS=""
+CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
+        -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security \
+        -fstack-clash-protection -fcf-protection \
+        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
+         -Wl,-z,pack-relative-relocs"
+LTOFLAGS="-flto=auto"
+#-- Make Flags: change this for DistCC/SMP systems
+MAKEFLAGS="-j$(nproc)"
+#-- Debugging flags
+DEBUG_CFLAGS="-g"
+DEBUG_CXXFLAGS="$DEBUG_CFLAGS"
+
+#########################################################################
+# BUILD ENVIRONMENT
+#########################################################################
+#
+# Makepkg defaults: BUILDENV=(!distcc !color !ccache check !sign)
+#  A negated environment option will do the opposite of the comments below.
+#
+#-- distcc:   Use the Distributed C/C++/ObjC compiler
+#-- color:    Colorize output messages
+#-- ccache:   Use ccache to cache compilation
+#-- check:    Run the check() function if present in the PKGBUILD
+#-- sign:     Generate PGP signature file
+#
+BUILDENV=(!distcc color !ccache check !sign)
+#
+#-- If using DistCC, your MAKEFLAGS will also need modification. In addition,
+#-- specify a space-delimited list of hosts running in the DistCC cluster.
+#DISTCC_HOSTS=""
+#
+#-- Specify a directory for package building.
+#BUILDDIR=/tmp/makepkg
+
+#########################################################################
+# GLOBAL PACKAGE OPTIONS
+#   These are default values for the options=() settings
+#########################################################################
+#
+# Makepkg defaults: OPTIONS=(!strip docs libtool staticlibs emptydirs !zipman !purge !debug !lto !autodeps)
+#  A negated option will do the opposite of the comments below.
+#
+#-- strip:      Strip symbols from binaries/libraries
+#-- docs:       Save doc directories specified by DOC_DIRS
+#-- libtool:    Leave libtool (.la) files in packages
+#-- staticlibs: Leave static library (.a) files in packages
+#-- emptydirs:  Leave empty directories in packages
+#-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
+#-- purge:      Remove files specified by PURGE_TARGETS
+#-- debug:      Add debugging flags as specified in DEBUG_* variables
+#-- lto:        Add compile flags for building with link time optimization
+#-- autodeps:   Automatically add depends/provides
+#
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge debug lto)
+
+#-- File integrity checks to use. Valid: md5, sha1, sha224, sha256, sha384, sha512, b2
+INTEGRITY_CHECK=(sha256)
+#-- Options to be used when stripping binaries. See `man strip' for details.
+STRIP_BINARIES="--strip-all"
+#-- Options to be used when stripping shared libraries. See `man strip' for details.
+STRIP_SHARED="--strip-unneeded"
+#-- Options to be used when stripping static libraries. See `man strip' for details.
+STRIP_STATIC="--strip-debug"
+#-- Manual (man and info) directories to compress (if zipman is specified)
+MAN_DIRS=({usr{,/local}{,/share},opt/*}/{man,info})
+#-- Doc directories to remove (if !docs is specified)
+DOC_DIRS=(usr/{,local/}{,share/}{doc,gtk-doc} opt/*/{doc,gtk-doc})
+#-- Files to be removed from all packages (if purge is specified)
+PURGE_TARGETS=(usr/{,share}/info/dir .packlist *.pod)
+#-- Directory to store source code in for debug packages
+DBGSRCDIR="/usr/src/debug"
+#-- Prefix and directories for library autodeps
+LIB_DIRS=('lib:usr/lib' 'lib32:usr/lib32')
+
+#########################################################################
+# PACKAGE OUTPUT
+#########################################################################
+#
+# Default: put built package and cached source in build directory
+#
+#-- Destination: specify a fixed directory where all packages will be placed
+#PKGDEST=/home/packages
+#-- Source cache: specify a fixed directory where source files will be cached
+#SRCDEST=/home/sources
+#-- Source packages: specify a fixed directory where all src packages will be placed
+#SRCPKGDEST=/home/srcpackages
+#-- Log files: specify a fixed directory where all log files will be placed
+#LOGDEST=/home/makepkglogs
+#-- Packager: name/email of the person or organization building packages
+#PACKAGER="John Doe <john@doe.com>"
+#-- Specify a key to use for package signing
+#GPGKEY=""
+
+#########################################################################
+# COMPRESSION DEFAULTS
+#########################################################################
+#
+COMPRESSGZ=(gzip -c -f -n)
+COMPRESSBZ2=(bzip2 -c -f)
+COMPRESSXZ=(xz -c -z -)
+COMPRESSZST=(zstd -c -T0 --auto-threads=logical -)
+COMPRESSLRZ=(lrzip -q)
+COMPRESSLZO=(lzop -q)
+COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
+
+#########################################################################
+# EXTENSION DEFAULTS
+#########################################################################
+#
+PKGEXT='.pkg.tar.zst'
+SRCEXT='.src.tar.gz'
+
+#########################################################################
+# OTHER
+#########################################################################
+#
+#-- Command used to run pacman as root, instead of trying sudo and su
+#PACMAN_AUTH=()
+# vim: set ft=sh ts=2 sw=2 et:

--- a/catos-iso/airootfs/etc/makepkg.conf
+++ b/catos-iso/airootfs/etc/makepkg.conf
@@ -1,0 +1,165 @@
+#!/hint/bash
+# shellcheck disable=2034
+
+#
+# /etc/makepkg.conf
+#
+
+#########################################################################
+# SOURCE ACQUISITION
+#########################################################################
+#
+#-- The download utilities that makepkg should use to acquire sources
+#  Format: 'protocol::agent'
+DLAGENTS=('file::/usr/bin/curl -qgC - -o %o %u'
+          'ftp::/usr/bin/curl -qgfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o %u'
+          'http::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'https::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'rsync::/usr/bin/rsync --no-motd -z %u %o'
+          'scp::/usr/bin/scp -C %u %o')
+
+# Other common tools:
+# /usr/bin/snarf
+# /usr/bin/lftpget -c
+# /usr/bin/wget
+
+#-- The package required by makepkg to download VCS sources
+#  Format: 'protocol::package'
+VCSCLIENTS=('bzr::breezy'
+            'fossil::fossil'
+            'git::git'
+            'hg::mercurial'
+            'svn::subversion')
+
+#########################################################################
+# ARCHITECTURE, COMPILE FLAGS
+#########################################################################
+#
+CARCH="x86_64"
+CHOST="x86_64-pc-linux-gnu"
+
+#-- Compiler and Linker Flags
+#CPPFLAGS=""
+CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
+        -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security \
+        -fstack-clash-protection -fcf-protection \
+        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
+         -Wl,-z,pack-relative-relocs"
+LTOFLAGS="-flto=auto"
+#-- Make Flags: change this for DistCC/SMP systems
+MAKEFLAGS="-j$(nproc)"
+#-- Debugging flags
+DEBUG_CFLAGS="-g"
+DEBUG_CXXFLAGS="$DEBUG_CFLAGS"
+
+#########################################################################
+# BUILD ENVIRONMENT
+#########################################################################
+#
+# Makepkg defaults: BUILDENV=(!distcc !color !ccache check !sign)
+#  A negated environment option will do the opposite of the comments below.
+#
+#-- distcc:   Use the Distributed C/C++/ObjC compiler
+#-- color:    Colorize output messages
+#-- ccache:   Use ccache to cache compilation
+#-- check:    Run the check() function if present in the PKGBUILD
+#-- sign:     Generate PGP signature file
+#
+BUILDENV=(!distcc color !ccache check !sign)
+#
+#-- If using DistCC, your MAKEFLAGS will also need modification. In addition,
+#-- specify a space-delimited list of hosts running in the DistCC cluster.
+#DISTCC_HOSTS=""
+#
+#-- Specify a directory for package building.
+#BUILDDIR=/tmp/makepkg
+
+#########################################################################
+# GLOBAL PACKAGE OPTIONS
+#   These are default values for the options=() settings
+#########################################################################
+#
+# Makepkg defaults: OPTIONS=(!strip docs libtool staticlibs emptydirs !zipman !purge !debug !lto !autodeps)
+#  A negated option will do the opposite of the comments below.
+#
+#-- strip:      Strip symbols from binaries/libraries
+#-- docs:       Save doc directories specified by DOC_DIRS
+#-- libtool:    Leave libtool (.la) files in packages
+#-- staticlibs: Leave static library (.a) files in packages
+#-- emptydirs:  Leave empty directories in packages
+#-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
+#-- purge:      Remove files specified by PURGE_TARGETS
+#-- debug:      Add debugging flags as specified in DEBUG_* variables
+#-- lto:        Add compile flags for building with link time optimization
+#-- autodeps:   Automatically add depends/provides
+#
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge debug lto)
+
+#-- File integrity checks to use. Valid: md5, sha1, sha224, sha256, sha384, sha512, b2
+INTEGRITY_CHECK=(sha256)
+#-- Options to be used when stripping binaries. See `man strip' for details.
+STRIP_BINARIES="--strip-all"
+#-- Options to be used when stripping shared libraries. See `man strip' for details.
+STRIP_SHARED="--strip-unneeded"
+#-- Options to be used when stripping static libraries. See `man strip' for details.
+STRIP_STATIC="--strip-debug"
+#-- Manual (man and info) directories to compress (if zipman is specified)
+MAN_DIRS=({usr{,/local}{,/share},opt/*}/{man,info})
+#-- Doc directories to remove (if !docs is specified)
+DOC_DIRS=(usr/{,local/}{,share/}{doc,gtk-doc} opt/*/{doc,gtk-doc})
+#-- Files to be removed from all packages (if purge is specified)
+PURGE_TARGETS=(usr/{,share}/info/dir .packlist *.pod)
+#-- Directory to store source code in for debug packages
+DBGSRCDIR="/usr/src/debug"
+#-- Prefix and directories for library autodeps
+LIB_DIRS=('lib:usr/lib' 'lib32:usr/lib32')
+
+#########################################################################
+# PACKAGE OUTPUT
+#########################################################################
+#
+# Default: put built package and cached source in build directory
+#
+#-- Destination: specify a fixed directory where all packages will be placed
+#PKGDEST=/home/packages
+#-- Source cache: specify a fixed directory where source files will be cached
+#SRCDEST=/home/sources
+#-- Source packages: specify a fixed directory where all src packages will be placed
+#SRCPKGDEST=/home/srcpackages
+#-- Log files: specify a fixed directory where all log files will be placed
+#LOGDEST=/home/makepkglogs
+#-- Packager: name/email of the person or organization building packages
+#PACKAGER="John Doe <john@doe.com>"
+#-- Specify a key to use for package signing
+#GPGKEY=""
+
+#########################################################################
+# COMPRESSION DEFAULTS
+#########################################################################
+#
+COMPRESSGZ=(gzip -c -f -n)
+COMPRESSBZ2=(bzip2 -c -f)
+COMPRESSXZ=(xz -c -z -)
+COMPRESSZST=(zstd -c -T0 --auto-threads=logical -)
+COMPRESSLRZ=(lrzip -q)
+COMPRESSLZO=(lzop -q)
+COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
+
+#########################################################################
+# EXTENSION DEFAULTS
+#########################################################################
+#
+PKGEXT='.pkg.tar.zst'
+SRCEXT='.src.tar.gz'
+
+#########################################################################
+# OTHER
+#########################################################################
+#
+#-- Command used to run pacman as root, instead of trying sudo and su
+#PACMAN_AUTH=()
+# vim: set ft=sh ts=2 sw=2 et:


### PR DESCRIPTION
This pull request adds a customized `makepkg.conf` to improve build times:
1. [Parallel compilation](https://wiki.archlinux.org/title/Makepkg#Parallel_compilation)
2. [Utilize multiple cores on compression](https://wiki.archlinux.org/title/Makepkg#Use_other_compression_algorithms)